### PR TITLE
Add gradient accumulation parameter to validation data reader

### DIFF
--- a/workflows/recipes/wav2vec2/asr/recipe.py
+++ b/workflows/recipes/wav2vec2/asr/recipe.py
@@ -193,6 +193,7 @@ class Wav2Vec2AsrRecipe(TrainRecipe):
                     tokenizer=context.default_tokenizer,
                     gangs=context.gangs,
                     dtype=config.trainer.mixed_precision.dtype,
+                    num_accumulate=config.trainer.grad_accumulation.num_batches,
                     storage_config=storage_config,  # type: ignore
                     task_config=task_config,  # type: ignore
                 )


### PR DESCRIPTION
## Why?
The validation data reader was missing the required [num_accumulate](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) parameter, causing a TypeError during training initialization when validation splits are enabled, preventing users from running any training with validation.