### PR TITLE
In HF Dataprep CLI, infer num_cpus based on what is available.

### DIFF
--- a/workflows/dataprep/hf_dataset_ingestion_example.py
+++ b/workflows/dataprep/hf_dataset_ingestion_example.py
@@ -193,7 +193,7 @@ class DataPrepCLI:
                 ray_ds_stream_ = ray.data.from_huggingface(mls_hf)
 
                 # Use batch-level text processing
-                num_cpus = max(floor(os.cpu_count()/4), 1)
+                num_cpus = max(floor((os.cpu_count() or 1) / 4), 1)
                 ray_ds_stream_ = ray_ds_stream_.map_batches(
                     MLSTextProcessor,
                     fn_constructor_kwargs={"lang": lang},
@@ -252,7 +252,7 @@ class DataPrepCLI:
                 ray_ds_stream_ = ray.data.from_huggingface(fleurs_hf)
 
                 # Use batch-level text processing
-                num_cpus = max(floor(os.cpu_count()/4), 1)
+                num_cpus = max(floor((os.cpu_count() or 1) / 4), 1)
                 ray_ds_stream_ = ray_ds_stream_.map_batches(
                     FleursTextProcessor,
                     fn_constructor_kwargs={"lang": lang},


### PR DESCRIPTION
## Why?
Currently the HF dataprep example script uses 10 cores for parallel-processing. But this won't work in all environments. Eg on GoogleCollab notebook this stalls out because there aren't the necessary resources.

## How ?
Infer number of available cpus, and use this to determine number of parallel threads for data processing.

## Test plan
Run the HF dataprep script on default Collab notebook.