### PR TITLE
Fix order of bos_idx and eos_idx assignment

### DIFF
--- a/src/omnilingual_asr/models/wav2vec2_llama/model.py
+++ b/src/omnilingual_asr/models/wav2vec2_llama/model.py
@@ -839,7 +839,7 @@ class Wav2Vec2LlamaModel(AsrModel):
         context_end_input = create_single_char_input(
             batch, self.special_tokens.context_end, device=device
         )
-        eos_idx, bos_idx = self._get_bos_eos()
+        bos_idx, eos_idx = self._get_bos_eos()
         bos_input = create_single_char_input(batch, bos_idx, device=device)
         eos_input = create_single_char_input(batch, eos_idx, device=device)
 


### PR DESCRIPTION
  Why?

  Fixed incorrect variable assignment order for BOS/EOS token indices in the create_zero_shot_syntax method. The original code assigned eos_idx to the BOS token and bos_idx to the EOS token, causing the model to use incorrect special tokens during sequence construction. This bug would lead to malformed input sequences and potentially incorrect model predictions in zero-shot learning scenarios.

  How?

  Technical Decision:
  - Swapped the variable assignment order from eos_idx, bos_idx = self._get_bos_eos() to bos_idx, eos_idx = self._get_bos_eos()
  - This ensures bos_idx receives the beginning-of-sequence token index and eos_idx receives the end-of-sequence token index
  - The fix aligns with the subsequent usage where bos_idx is used to create bos_input (line 843) and eos_idx is used to create eos_input (line 844)

  Location:
  - File: src/omnilingual_asr/models/wav2vec2_llama/model.py
  - Line: 842

  Test Plan

  Testing Approach:
  1. Verified that _get_bos_eos() returns tokens in the order (bos_token, eos_token)
  2. Traced through the zero-shot syntax creation to confirm BOS tokens are correctly placed at sequence beginnings
  3. Validated that EOS tokens are correctly placed at sequence endings
  4. Ran existing unit tests for the create_zero_shot_syntax method to ensure no regressions

  Reproduction:
  - Before fix: BOS and EOS tokens would be swapped in generated sequences
  - After fix: Tokens are correctly positioned according to their semantic meaning